### PR TITLE
Add missing includes, improve help output, format readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # compoundfilereader
-simple standalone c++ header file to read compound file (Structured Storage File) content.
+Simple standalone C++ header file to read compound file (Structured Storage File) content.
 
 # Source code structure
 - **src/include/compoundfilereader.h**
@@ -9,28 +9,28 @@ simple standalone c++ header file to read compound file (Structured Storage File
 - **test/data**
   Real world compound files for tests.
 - **samples/cfb**
-  command line tool to list and dump compound files.
+  Command line tool to list and dump compound files.
 - **samples/IEOpenedTabParser**
-  command line tool to show IE opened tab information.
+  Command line tool to show IE opened tab information.
 - **vsproject**
-  project and solution files for Microsoft Visual Studio.
+  Project and solution files for Microsoft Visual Studio.
 
 # Usage
-- copy compoundfilereader.h to your source tree
-  or: install "compoundfilereader" by git sub-module
-- #include <compoundfilereader.h> in your source code
-- construct a **CompoundFileReader** object by giving the buffer (see compoundfilereader.h for details)
+- Copy compoundfilereader.h to your source tree
+  or: install "compoundfilereader" by git submodule
+- `#include <compoundfilereader.h>` in your source code
+- Construct a **CompoundFileReader** object by giving the buffer (see compoundfilereader.h for details)
 
 # Build the samples
 ## Linux
-run `make'
+Run `make`
 (requires gcc and g++)
 ## Windows
-option1: double click 'vsproject\cfbreader\cfbreader.sln' then build in Visual Studio
-option2: run 'build.bat' in Visual Studio Command Prompt
-(requires visual studio)
+- Option 1: double click 'vsproject\cfbreader\cfbreader.sln' then build in Visual Studio
+- Option 2: run 'build.bat' in Visual Studio Command Prompt
+(requires Visual Studio)
 ## Run the samples
-try the following:
+Try the following:
 ``` batchfile
 out/ieot "test/data/{BC59C035-E8AC-11E4-825B-10604B7CB9F0}.dat"
 out/cfb list "test/data/a test email message.msg"
@@ -38,9 +38,8 @@ out/cfb dump "test/data/a test email message.msg" __properties_version1.0
 ```
 
 # TODO
-- unit tests
-- make the reader able to connect to abstract interfaces such as istream
+- Unit tests
+- Make the reader able to connect to abstract interfaces such as istream
 
-#Microsoft Open Source Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments. 
+# Microsoft Open Source Code of Conduct
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/samples/IEOpenedTabParser/IEOpenedTabParser.h
+++ b/samples/IEOpenedTabParser/IEOpenedTabParser.h
@@ -7,6 +7,7 @@
 #include <compoundfilereader.h>
 #include <utf.h>
 #include <string>
+#include <limits>
 #include <vector>
 
 struct OPENED_TAB_INFO

--- a/samples/cfb/cfb.cpp
+++ b/samples/cfb/cfb.cpp
@@ -14,7 +14,7 @@ void ShowUsage()
     cout <<
         "usage:\n"
         "cfb list FILENAME\n"
-        "cfb dump FILENAME STREAM_PATH\n"
+        "cfb dump [-r] FILENAME STREAM_PATH\n"
         "cfb info FILENAME\n"
         "cfb info FILENAME STREAM_PATH\n"
         << endl;

--- a/samples/cfb/cfb.cpp
+++ b/samples/cfb/cfb.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <iostream>
 #include <iomanip>
+#include <limits>
 
 using namespace std;
 


### PR DESCRIPTION
Hello!

The project did not compile for me because the `<limits>` header was missing. Also, the -r argument of the dump command was documented nowhere, so I added that to the usage instructions. Lastly, I did some basic formatting of the readme.
Hope this can be merged :)

Best regards,
Julian