### PR TITLE
Include <string> to make it compilable on MacOS

### DIFF
--- a/src/include/compoundfilereader.h
+++ b/src/include/compoundfilereader.h
@@ -36,6 +36,7 @@
 #include <exception>
 #include <stdexcept>
 #include <functional>
+#include <string>
 
 namespace CFB
 {


### PR DESCRIPTION
Hello.
To build this project on MacOS,
```
#include <string>
```
Is needed. Otherwise, the following error is generated. 


```
src/include/compoundfilereader.h:228:21: error: implicit instantiation of undefined template 'std::basic_string<unsigned short>'
        utf16string dir;
                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:105:7: note: template is declared here
      basic_string;
      ^
In file included from samples/IEOpenedTabParser/openedtab.cpp:1:
In file included from samples/IEOpenedTabParser/IEOpenedTabParser.h:7:
src/include/compoundfilereader.h:248:25: error: implicit instantiation of undefined template 'std::basic_string<unsigned short>'
            utf16string newDir = dir;
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:105:7: note: template is declared here
      basic_string;
      ^
In file included from samples/IEOpenedTabParser/openedtab.cpp:1:
In file included from samples/IEOpenedTabParser/IEOpenedTabParser.h:7:
src/include/compoundfilereader.h:249:20: error: implicit instantiation of undefined template 'std::basic_string<unsigned short>'
            if (dir.length() != 0)
                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:105:7: note: template is declared here
      basic_string;
      ^
3 errors generated.
make: *** [out/ieot] Error 1
```