### PR TITLE
deprecate std::basic_string<uint16_t>

### DIFF
--- a/samples/IEOpenedTabParser/IEOpenedTabParser.h
+++ b/samples/IEOpenedTabParser/IEOpenedTabParser.h
@@ -23,7 +23,7 @@ struct OpenedTabFileParser
     {
         const CFB::COMPOUND_FILE_ENTRY* entry = nullptr;
         reader.EnumFiles(reader.GetRootEntry(), -1, 
-            [&](const CFB::COMPOUND_FILE_ENTRY* e, const CFB::utf16string&, int)->void
+            [&](const CFB::COMPOUND_FILE_ENTRY* e, const std::u16string&, int)->void
         {
             if (reader.IsPropertyStream(e))
             {

--- a/samples/cfb/cfb.cpp
+++ b/samples/cfb/cfb.cpp
@@ -132,7 +132,7 @@ void OutputEntryInfo(const CFB::CompoundFileReader& reader, const CFB::COMPOUND_
 const void ListDirectory(const CFB::CompoundFileReader& reader, bool escape)
 {
     reader.EnumFiles(reader.GetRootEntry(), -1, 
-        [&](const CFB::COMPOUND_FILE_ENTRY* entry, const CFB::utf16string& dir, int level)->void
+        [&](const CFB::COMPOUND_FILE_ENTRY* entry, const std::u16string& dir, int level)->void
     {
         bool isDirectory = !reader.IsStream(entry);
         std::string name = UTF16ToUTF8(entry->name);
@@ -146,7 +146,7 @@ const CFB::COMPOUND_FILE_ENTRY* FindStream(const CFB::CompoundFileReader& reader
 {
     const CFB::COMPOUND_FILE_ENTRY* ret = nullptr;
     reader.EnumFiles(reader.GetRootEntry(), -1, 
-        [&](const CFB::COMPOUND_FILE_ENTRY* entry, const CFB::utf16string& u16dir, int level)->void
+        [&](const CFB::COMPOUND_FILE_ENTRY* entry, const std::u16string& u16dir, int level)->void
     {
         if (reader.IsStream(entry))
         {

--- a/src/include/compoundfilereader.h
+++ b/src/include/compoundfilereader.h
@@ -132,8 +132,7 @@ struct helper
     }
 };
 
-typedef std::basic_string<uint16_t> utf16string;
-typedef std::function<void(const COMPOUND_FILE_ENTRY*, const utf16string& dir, int level)> 
+typedef std::function<void(const COMPOUND_FILE_ENTRY*, const std::u16string& dir, int level)> 
     EnumFilesCallback;
 
 class CompoundFileReader
@@ -226,7 +225,7 @@ public:
 
     void EnumFiles(const COMPOUND_FILE_ENTRY* entry, int maxLevel, EnumFilesCallback callback) const
     {
-        utf16string dir;
+        std::u16string dir;
         EnumNodes(GetEntry(entry->childID), 0, maxLevel, dir, callback);
     }
 
@@ -234,7 +233,7 @@ private:
 
     // Enum entries with same level, including 'entry' itself
     void EnumNodes(const COMPOUND_FILE_ENTRY* entry, int currentLevel, int maxLevel, 
-        const utf16string& dir, EnumFilesCallback callback) const
+        const std::u16string& dir, EnumFilesCallback callback) const
     {
         if (maxLevel > 0 && currentLevel >= maxLevel)
             return;
@@ -246,10 +245,10 @@ private:
         const COMPOUND_FILE_ENTRY* child = GetEntry(entry->childID);
         if (child != nullptr)
         {
-            utf16string newDir = dir;
+            std::u16string newDir = dir;
             if (dir.length() != 0)
                 newDir.append(1, '\\');
-            newDir.append(entry->name, entry->nameLen / 2 - 1);
+            newDir.append(reinterpret_cast<const char16_t*>(entry->name), entry->nameLen / 2 - 1);
             EnumNodes(GetEntry(entry->childID), currentLevel + 1, maxLevel, newDir, callback);
         }
 


### PR DESCRIPTION
Building CompoundFileReader fails in Xcode 16.3 Beta because the base template for std::char_traits has been removed:

> Implicit instantiation of undefined template 'std::char_traits<unsigned short>'

Replace it with `std::u16string` as @timepp suggested in #13.

Deprecations announcements:
[Deprecations in Xcode 16.3 Beta](https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes#Deprecations-in-Xcode-163-Beta)
[[libc++] Remove default definition of std::char_traits](https://reviews.llvm.org/D138307)