### PR TITLE
Fixed microsoft/compoundfilereader#15

### DIFF
--- a/src/include/utf.h
+++ b/src/include/utf.h
@@ -4,7 +4,7 @@
 #include <string>
 
 template <typename T>
-static bool GetNextCodePointFromUTF16z(const T* u16, size_t* pos, uint32_t* cp)
+bool GetNextCodePointFromUTF16z(const T* u16, size_t* pos, uint32_t* cp)
 {
     *cp = static_cast<uint32_t>(u16[*pos]);
     if (*cp == 0)
@@ -24,7 +24,7 @@ static bool GetNextCodePointFromUTF16z(const T* u16, size_t* pos, uint32_t* cp)
 }
 
 template <typename T>
-static bool GetNextCodePointFromUTF16(const T* u16, size_t len, size_t* pos, uint32_t* cp)
+bool GetNextCodePointFromUTF16(const T* u16, size_t len, size_t* pos, uint32_t* cp)
 {
     if (len == 0)
         return GetNextCodePointFromUTF16z(u16, pos, cp);
@@ -49,7 +49,7 @@ static bool GetNextCodePointFromUTF16(const T* u16, size_t len, size_t* pos, uin
     return true;
 }
 
-static int CodePointToUTF8(uint32_t cp, uint32_t* c1, uint32_t* c2, uint32_t* c3, uint32_t* c4)
+inline int CodePointToUTF8(uint32_t cp, uint32_t* c1, uint32_t* c2, uint32_t* c3, uint32_t* c4)
 {
     if (cp < 0x80)
     {


### PR DESCRIPTION
For fixing #15 the static keyword in front of functions was either removed (templates) or replace with inline. 